### PR TITLE
Fixed typo in CSRFGuard name

### DIFF
--- a/index.md
+++ b/index.md
@@ -1,7 +1,7 @@
 ---
 
 layout: col-sidebar
-title: OWASP CSFRGuard
+title: OWASP CSRFGuard
 site_side: true
 tags: csrfguard
 project: true


### PR DESCRIPTION
I'm assuming this was an error, noticed it when I was browsing the docs.

I haven't built the project and I'm not familiar with the codebase at all, but I'm assuming a tiny change in the docs doesn't break anything.