### PR TITLE
Added flag to initialise the javascript settings for new ConfigurationProvider instances

### DIFF
--- a/csrfguard/src/main/java/org/owasp/csrfguard/CsrfGuard.java
+++ b/csrfguard/src/main/java/org/owasp/csrfguard/CsrfGuard.java
@@ -65,10 +65,7 @@ public class CsrfGuard {
 
     private Properties properties = null;
 
-    /**
-     * Flag indicating that the JavaScript configuration must be initialised when no configuration is retrieved.
-     */
-    private boolean initialiseJavaScriptConfigurationForNewConfigurationInstances;
+    private boolean isJavaScriptConfigurationNeeded;
 
     public CsrfGuard() {}
 
@@ -182,7 +179,7 @@ public class CsrfGuard {
      */
     public void initializeJavaScriptConfiguration() {
         config().initializeJavaScriptConfiguration();
-        initialiseJavaScriptConfigurationForNewConfigurationInstances = true;
+        this.isJavaScriptConfigurationNeeded = true;
     }
 
     /**
@@ -409,7 +406,7 @@ public class CsrfGuard {
         final ConfigurationProviderFactory configurationProviderFactory = CsrfGuardUtils.newInstance(configurationProviderFactoryClass);
 
         configurationProvider = configurationProviderFactory.retrieveConfiguration(this.properties);
-        if (initialiseJavaScriptConfigurationForNewConfigurationInstances) {
+        if (this.isJavaScriptConfigurationNeeded) {
             configurationProvider.initializeJavaScriptConfiguration();
         }
 

--- a/csrfguard/src/main/java/org/owasp/csrfguard/CsrfGuard.java
+++ b/csrfguard/src/main/java/org/owasp/csrfguard/CsrfGuard.java
@@ -65,6 +65,11 @@ public class CsrfGuard {
 
     private Properties properties = null;
 
+    /**
+     * Flag indicating that the JavaScript configuration must be initialised when no configuration is retrieved.
+     */
+    private boolean initialiseJavaScriptConfigurationForNewConfigurationInstances;
+
     public CsrfGuard() {}
 
     public static CsrfGuard getInstance() {
@@ -177,6 +182,7 @@ public class CsrfGuard {
      */
     public void initializeJavaScriptConfiguration() {
         config().initializeJavaScriptConfiguration();
+        initialiseJavaScriptConfigurationForNewConfigurationInstances = true;
     }
 
     /**
@@ -403,6 +409,10 @@ public class CsrfGuard {
         final ConfigurationProviderFactory configurationProviderFactory = CsrfGuardUtils.newInstance(configurationProviderFactoryClass);
 
         configurationProvider = configurationProviderFactory.retrieveConfiguration(this.properties);
+        if (initialiseJavaScriptConfigurationForNewConfigurationInstances) {
+            configurationProvider.initializeJavaScriptConfiguration();
+        }
+
         configurationProviderExpirableCache.put(Boolean.TRUE, configurationProvider);
         return configurationProvider;
     }


### PR DESCRIPTION
When a new `ConfigurationProvider` instance is created, the JavaScript settings are not initialized. The initialization of these settings now only happens when the `JavaScriptServlet` is initialized. 
In this PR I added a flag so that the `CsrfGuard` class knows that the JavaScript settings are needed and that they must be initialized for new `ConfigurationProvider` instances.