### PR TITLE
Adding support for un-exploded deployments

### DIFF
--- a/csrfguard/src/main/java/org/owasp/csrfguard/CsrfGuardServletContextListener.java
+++ b/csrfguard/src/main/java/org/owasp/csrfguard/CsrfGuardServletContextListener.java
@@ -142,9 +142,14 @@ public class CsrfGuardServletContextListener implements ServletContextListener {
 
 	private InputStream getResourceStream(final String resourceName, final ServletContext context, final boolean failIfNotFound) throws IOException {
 		InputStream inputStream;
+		
+		/* In case of Unexplored war, read file from the context path */
+		inputStream = context.getResourceAsStream(resourceName);
 
 		/* try classpath */
-		inputStream = getClass().getClassLoader().getResourceAsStream(resourceName);
+		if (inputStream == null) {
+			inputStream = getClass().getClassLoader().getResourceAsStream(resourceName);
+		}
 
 		/* try web context */
 		if (inputStream == null) {

--- a/csrfguard/src/main/java/org/owasp/csrfguard/util/CsrfGuardUtils.java
+++ b/csrfguard/src/main/java/org/owasp/csrfguard/util/CsrfGuardUtils.java
@@ -138,7 +138,7 @@ public final class CsrfGuardUtils {
         return resourceURI.startsWith("/") ? resourceURI : '/' + resourceURI;
     }
 
-    private static String readInputStreamContent(final InputStream inputStream) {
+    public static String readInputStreamContent(final InputStream inputStream) {
         try {
             return IOUtils.toString(inputStream, Charset.defaultCharset());
         } catch (final IOException ioe) {


### PR DESCRIPTION
In case of unexplore deployment when we try to find the real file path we get null, thus we are not able to read the file, so instead of finding the real path we can read file from context path.