### PR TITLE
javax.servlet to jakarta.servlet

### DIFF
--- a/csrfguard-extensions/csrfguard-extension-session/pom.xml
+++ b/csrfguard-extensions/csrfguard-extension-session/pom.xml
@@ -49,8 +49,8 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
+            <groupId>jakarta.servlet</groupId>
+	  		    <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/csrfguard-extensions/csrfguard-extension-session/src/main/java/org/owasp/csrfguard/CsrfGuardHttpSessionListener.java
+++ b/csrfguard-extensions/csrfguard-extension-session/src/main/java/org/owasp/csrfguard/CsrfGuardHttpSessionListener.java
@@ -32,9 +32,9 @@ package org.owasp.csrfguard;
 import org.owasp.csrfguard.session.ContainerSession;
 import org.owasp.csrfguard.session.LogicalSession;
 
-import javax.servlet.http.HttpSession;
-import javax.servlet.http.HttpSessionEvent;
-import javax.servlet.http.HttpSessionListener;
+import jakarta.servlet.http.HttpSession;
+import jakarta.servlet.http.HttpSessionEvent;
+import jakarta.servlet.http.HttpSessionListener;
 
 public class CsrfGuardHttpSessionListener implements HttpSessionListener {
 

--- a/csrfguard-extensions/csrfguard-extension-session/src/main/java/org/owasp/csrfguard/action/SessionAttribute.java
+++ b/csrfguard-extensions/csrfguard-extension-session/src/main/java/org/owasp/csrfguard/action/SessionAttribute.java
@@ -34,8 +34,8 @@ import org.owasp.csrfguard.CsrfGuardException;
 import org.owasp.csrfguard.config.properties.ConfigParameters;
 import org.owasp.csrfguard.session.LogicalSession;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.util.Objects;
 
 /**

--- a/csrfguard-extensions/csrfguard-extension-session/src/main/java/org/owasp/csrfguard/session/ContainerSession.java
+++ b/csrfguard-extensions/csrfguard-extension-session/src/main/java/org/owasp/csrfguard/session/ContainerSession.java
@@ -28,7 +28,7 @@
  */
 package org.owasp.csrfguard.session;
 
-import javax.servlet.http.HttpSession;
+import jakarta.servlet.http.HttpSession;
 import java.util.Objects;
 
 public class ContainerSession implements LogicalSession {

--- a/csrfguard-extensions/csrfguard-extension-session/src/main/java/org/owasp/csrfguard/session/SessionTokenKeyExtractor.java
+++ b/csrfguard-extensions/csrfguard-extension-session/src/main/java/org/owasp/csrfguard/session/SessionTokenKeyExtractor.java
@@ -30,8 +30,8 @@ package org.owasp.csrfguard.session;
 
 import org.owasp.csrfguard.token.storage.LogicalSessionExtractor;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpSession;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
 import java.util.Objects;
 
 public class SessionTokenKeyExtractor implements LogicalSessionExtractor {

--- a/csrfguard-extensions/csrfguard-jsp-tags/pom.xml
+++ b/csrfguard-extensions/csrfguard-jsp-tags/pom.xml
@@ -61,16 +61,16 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
+            <groupId>jakarta.servlet.jsp</groupId>
+			      <artifactId>jakarta.servlet.jsp-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.servlet.jsp</groupId>
-            <artifactId>jsp-api</artifactId>
+            <groupId>jakarta.servlet.jsp</groupId>
+            <artifactId>jakarta.servlet.jsp-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.servlet.jsp.jstl</groupId>
-            <artifactId>jstl-api</artifactId>
+            <groupId>jakarta.servlet.jsp.jstl</groupId>
+            <artifactId>jakarta.servlet.jsp.jstl-api</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/csrfguard-extensions/csrfguard-jsp-tags/src/main/java/org/owasp/csrfguard/tag/ATag.java
+++ b/csrfguard-extensions/csrfguard-jsp-tags/src/main/java/org/owasp/csrfguard/tag/ATag.java
@@ -33,8 +33,8 @@ import org.owasp.csrfguard.CsrfGuard;
 import org.owasp.csrfguard.session.LogicalSession;
 import org.owasp.csrfguard.util.BrowserEncoder;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.jsp.tagext.DynamicAttributes;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.jsp.tagext.DynamicAttributes;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;

--- a/csrfguard-extensions/csrfguard-jsp-tags/src/main/java/org/owasp/csrfguard/tag/AbstractTag.java
+++ b/csrfguard-extensions/csrfguard-jsp-tags/src/main/java/org/owasp/csrfguard/tag/AbstractTag.java
@@ -32,7 +32,7 @@ package org.owasp.csrfguard.tag;
 import org.owasp.csrfguard.CsrfValidator;
 import org.owasp.csrfguard.ProtectionResult;
 
-import javax.servlet.jsp.tagext.TagSupport;
+import jakarta.servlet.jsp.tagext.TagSupport;
 
 public abstract class AbstractTag extends TagSupport {
 

--- a/csrfguard-extensions/csrfguard-jsp-tags/src/main/java/org/owasp/csrfguard/tag/FormTag.java
+++ b/csrfguard-extensions/csrfguard-jsp-tags/src/main/java/org/owasp/csrfguard/tag/FormTag.java
@@ -33,9 +33,9 @@ import org.owasp.csrfguard.CsrfGuard;
 import org.owasp.csrfguard.session.LogicalSession;
 import org.owasp.csrfguard.util.BrowserEncoder;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.jsp.JspException;
-import javax.servlet.jsp.tagext.DynamicAttributes;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.jsp.JspException;
+import jakarta.servlet.jsp.tagext.DynamicAttributes;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;

--- a/csrfguard-extensions/csrfguard-jsp-tags/src/main/java/org/owasp/csrfguard/tag/TokenNameTag.java
+++ b/csrfguard-extensions/csrfguard-jsp-tags/src/main/java/org/owasp/csrfguard/tag/TokenNameTag.java
@@ -31,7 +31,7 @@ package org.owasp.csrfguard.tag;
 
 import org.owasp.csrfguard.CsrfGuard;
 
-import javax.servlet.jsp.tagext.TagSupport;
+import jakarta.servlet.jsp.tagext.TagSupport;
 import java.io.IOException;
 
 public final class TokenNameTag extends TagSupport {

--- a/csrfguard-extensions/csrfguard-jsp-tags/src/main/java/org/owasp/csrfguard/tag/TokenTag.java
+++ b/csrfguard-extensions/csrfguard-jsp-tags/src/main/java/org/owasp/csrfguard/tag/TokenTag.java
@@ -32,7 +32,7 @@ package org.owasp.csrfguard.tag;
 import org.owasp.csrfguard.CsrfGuard;
 import org.owasp.csrfguard.session.LogicalSession;
 
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 import java.io.IOException;
 import java.util.Objects;
 

--- a/csrfguard-extensions/csrfguard-jsp-tags/src/main/java/org/owasp/csrfguard/tag/TokenValueTag.java
+++ b/csrfguard-extensions/csrfguard-jsp-tags/src/main/java/org/owasp/csrfguard/tag/TokenValueTag.java
@@ -32,7 +32,7 @@ package org.owasp.csrfguard.tag;
 import org.owasp.csrfguard.CsrfGuard;
 import org.owasp.csrfguard.session.LogicalSession;
 
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 import java.io.IOException;
 import java.util.Objects;
 

--- a/csrfguard-test/csrfguard-test-jsp/pom.xml
+++ b/csrfguard-test/csrfguard-test-jsp/pom.xml
@@ -75,13 +75,14 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
+           <groupId>jakarta.servlet</groupId>
+           <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.servlet.jsp</groupId>
-            <artifactId>jsp-api</artifactId>
+           <groupId>jakarta.servlet.jsp</groupId>
+           <artifactId>jakarta.servlet.jsp-api</artifactId>
         </dependency>
+
 
         <dependency>
             <groupId>ch.qos.logback</groupId>

--- a/csrfguard-test/csrfguard-test-jsp/src/main/java/org/owasp/csrfguard/test/CORSFilter.java
+++ b/csrfguard-test/csrfguard-test-jsp/src/main/java/org/owasp/csrfguard/test/CORSFilter.java
@@ -30,8 +30,8 @@ package org.owasp.csrfguard.test;
 
 import org.owasp.csrfguard.CsrfGuard;
 
-import javax.servlet.*;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.*;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
 /**

--- a/csrfguard-test/csrfguard-test-jsp/src/main/java/org/owasp/csrfguard/test/CounterServlet.java
+++ b/csrfguard-test/csrfguard-test-jsp/src/main/java/org/owasp/csrfguard/test/CounterServlet.java
@@ -31,10 +31,10 @@ package org.owasp.csrfguard.test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import javax.servlet.http.HttpSession;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.Objects;

--- a/csrfguard/pom.xml
+++ b/csrfguard/pom.xml
@@ -43,8 +43,8 @@
 
 	<dependencies>
 		<dependency>
-			<groupId>javax.servlet</groupId>
-			<artifactId>servlet-api</artifactId>
+			<groupId>jakarta.servlet</groupId>
+			<artifactId>jakarta.servlet-api</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.commons</groupId>

--- a/csrfguard/src/main/java/org/owasp/csrfguard/CsrfGuard.java
+++ b/csrfguard/src/main/java/org/owasp/csrfguard/CsrfGuard.java
@@ -43,8 +43,8 @@ import org.owasp.csrfguard.token.storage.TokenHolder;
 import org.owasp.csrfguard.util.CsrfGuardPropertiesToStringBuilder;
 import org.owasp.csrfguard.util.CsrfGuardUtils;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.security.SecureRandom;
 import java.time.Duration;
@@ -299,7 +299,7 @@ public final class CsrfGuard {
     /**
      * Method to be called by a logical session implementation when a new session is created. <br>
      * <p>
-     * Example: {@link javax.servlet.http.HttpSessionListener#sessionCreated(javax.servlet.http.HttpSessionEvent)}
+     * Example: {@link jakarta.servlet.http.HttpSessionListener#sessionCreated(jakarta.servlet.http.HttpSessionEvent)}
      *
      * @param logicalSession a logical session implementation
      */
@@ -324,7 +324,7 @@ public final class CsrfGuard {
     /**
      * Method to be called by a logical session implementation when a session is destroyed. <br>
      * <p>
-     * Example: {@link javax.servlet.http.HttpSessionListener#sessionDestroyed(javax.servlet.http.HttpSessionEvent)}
+     * Example: {@link jakarta.servlet.http.HttpSessionListener#sessionDestroyed(jakarta.servlet.http.HttpSessionEvent)}
      *
      * @param logicalSession a logical session implementation
      */

--- a/csrfguard/src/main/java/org/owasp/csrfguard/CsrfGuardFilter.java
+++ b/csrfguard/src/main/java/org/owasp/csrfguard/CsrfGuardFilter.java
@@ -38,9 +38,9 @@ import org.owasp.csrfguard.util.CsrfGuardUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.servlet.*;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.*;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.Collections;
 

--- a/csrfguard/src/main/java/org/owasp/csrfguard/CsrfGuardServletContextListener.java
+++ b/csrfguard/src/main/java/org/owasp/csrfguard/CsrfGuardServletContextListener.java
@@ -32,9 +32,9 @@ package org.owasp.csrfguard;
 import org.apache.commons.lang3.StringUtils;
 import org.owasp.csrfguard.config.overlay.ConfigurationOverlayProvider;
 
-import javax.servlet.ServletContext;
-import javax.servlet.ServletContextEvent;
-import javax.servlet.ServletContextListener;
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.ServletContextEvent;
+import jakarta.servlet.ServletContextListener;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -118,7 +118,7 @@ public class CsrfGuardServletContextListener implements ServletContextListener {
 	 * Has no effect unless the CONFIG_PRINT_PARAM init parameter is "true."
 	 * @param context The ServletContext
 	 * @param prefix  The string used as a prefix when printing the configuration to the log
-	 * @see javax.servlet.ServletContext#log(String)
+	 * @see jakarta.servlet.ServletContext#log(String)
 	 */
 	public static void printConfigIfConfigured(final ServletContext context, final String prefix) {
 		final CsrfGuard csrfGuard = CsrfGuard.getInstance();

--- a/csrfguard/src/main/java/org/owasp/csrfguard/CsrfValidator.java
+++ b/csrfguard/src/main/java/org/owasp/csrfguard/CsrfValidator.java
@@ -42,8 +42,8 @@ import org.owasp.csrfguard.util.RegexValidationUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.util.Objects;
 import java.util.Set;
 import java.util.function.UnaryOperator;

--- a/csrfguard/src/main/java/org/owasp/csrfguard/action/Empty.java
+++ b/csrfguard/src/main/java/org/owasp/csrfguard/action/Empty.java
@@ -32,8 +32,8 @@ package org.owasp.csrfguard.action;
 import org.owasp.csrfguard.CsrfGuard;
 import org.owasp.csrfguard.CsrfGuardException;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 /**
  * TODO document or why it is needed or remove this Action

--- a/csrfguard/src/main/java/org/owasp/csrfguard/action/Error.java
+++ b/csrfguard/src/main/java/org/owasp/csrfguard/action/Error.java
@@ -32,8 +32,8 @@ package org.owasp.csrfguard.action;
 import org.owasp.csrfguard.CsrfGuard;
 import org.owasp.csrfguard.CsrfGuardException;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
 public final class Error extends AbstractAction {

--- a/csrfguard/src/main/java/org/owasp/csrfguard/action/Forward.java
+++ b/csrfguard/src/main/java/org/owasp/csrfguard/action/Forward.java
@@ -32,9 +32,9 @@ package org.owasp.csrfguard.action;
 import org.owasp.csrfguard.CsrfGuard;
 import org.owasp.csrfguard.CsrfGuardException;
 
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
 public final class Forward extends AbstractAction {

--- a/csrfguard/src/main/java/org/owasp/csrfguard/action/IAction.java
+++ b/csrfguard/src/main/java/org/owasp/csrfguard/action/IAction.java
@@ -32,8 +32,8 @@ package org.owasp.csrfguard.action;
 import org.owasp.csrfguard.CsrfGuard;
 import org.owasp.csrfguard.CsrfGuardException;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.Serializable;
 import java.util.Map;
 

--- a/csrfguard/src/main/java/org/owasp/csrfguard/action/Invalidate.java
+++ b/csrfguard/src/main/java/org/owasp/csrfguard/action/Invalidate.java
@@ -33,8 +33,8 @@ import org.owasp.csrfguard.CsrfGuard;
 import org.owasp.csrfguard.CsrfGuardException;
 import org.owasp.csrfguard.session.LogicalSession;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.util.Objects;
 
 public final class Invalidate extends AbstractAction {

--- a/csrfguard/src/main/java/org/owasp/csrfguard/action/Log.java
+++ b/csrfguard/src/main/java/org/owasp/csrfguard/action/Log.java
@@ -35,8 +35,8 @@ import org.owasp.csrfguard.CsrfGuardException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.security.Principal;
 
 public final class Log extends AbstractAction {

--- a/csrfguard/src/main/java/org/owasp/csrfguard/action/Redirect.java
+++ b/csrfguard/src/main/java/org/owasp/csrfguard/action/Redirect.java
@@ -32,8 +32,8 @@ package org.owasp.csrfguard.action;
 import org.owasp.csrfguard.CsrfGuard;
 import org.owasp.csrfguard.CsrfGuardException;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
 public final class Redirect extends AbstractAction {

--- a/csrfguard/src/main/java/org/owasp/csrfguard/action/RequestAttribute.java
+++ b/csrfguard/src/main/java/org/owasp/csrfguard/action/RequestAttribute.java
@@ -32,8 +32,8 @@ package org.owasp.csrfguard.action;
 import org.owasp.csrfguard.CsrfGuard;
 import org.owasp.csrfguard.CsrfGuardException;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 public final class RequestAttribute extends AbstractAction {
 

--- a/csrfguard/src/main/java/org/owasp/csrfguard/action/Rotate.java
+++ b/csrfguard/src/main/java/org/owasp/csrfguard/action/Rotate.java
@@ -34,8 +34,8 @@ import org.owasp.csrfguard.CsrfGuardException;
 import org.owasp.csrfguard.session.LogicalSession;
 import org.owasp.csrfguard.token.storage.LogicalSessionExtractor;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.util.Objects;
 
 public class Rotate extends AbstractAction {

--- a/csrfguard/src/main/java/org/owasp/csrfguard/config/PropertiesConfigurationProvider.java
+++ b/csrfguard/src/main/java/org/owasp/csrfguard/config/PropertiesConfigurationProvider.java
@@ -45,7 +45,7 @@ import org.owasp.csrfguard.util.RegexValidationUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.servlet.ServletConfig;
+import jakarta.servlet.ServletConfig;
 import java.io.IOException;
 import java.io.InputStream;
 import java.security.*;

--- a/csrfguard/src/main/java/org/owasp/csrfguard/config/properties/javascript/BooleanJsConfigParameter.java
+++ b/csrfguard/src/main/java/org/owasp/csrfguard/config/properties/javascript/BooleanJsConfigParameter.java
@@ -31,7 +31,7 @@ package org.owasp.csrfguard.config.properties.javascript;
 
 import org.owasp.csrfguard.config.properties.PropertyUtils;
 
-import javax.servlet.ServletConfig;
+import jakarta.servlet.ServletConfig;
 import java.util.Properties;
 
 public class BooleanJsConfigParameter extends JsConfigParameter<Boolean> {

--- a/csrfguard/src/main/java/org/owasp/csrfguard/config/properties/javascript/JsConfigParameter.java
+++ b/csrfguard/src/main/java/org/owasp/csrfguard/config/properties/javascript/JsConfigParameter.java
@@ -30,7 +30,7 @@ package org.owasp.csrfguard.config.properties.javascript;
 
 import org.apache.commons.lang3.StringUtils;
 
-import javax.servlet.ServletConfig;
+import jakarta.servlet.ServletConfig;
 import java.util.Properties;
 import java.util.function.Function;
 

--- a/csrfguard/src/main/java/org/owasp/csrfguard/config/properties/javascript/StringJsConfigParameter.java
+++ b/csrfguard/src/main/java/org/owasp/csrfguard/config/properties/javascript/StringJsConfigParameter.java
@@ -31,7 +31,7 @@ package org.owasp.csrfguard.config.properties.javascript;
 
 import org.owasp.csrfguard.config.properties.PropertyUtils;
 
-import javax.servlet.ServletConfig;
+import jakarta.servlet.ServletConfig;
 import java.util.Properties;
 
 public class StringJsConfigParameter extends JsConfigParameter<String> {

--- a/csrfguard/src/main/java/org/owasp/csrfguard/http/InterceptRedirectResponse.java
+++ b/csrfguard/src/main/java/org/owasp/csrfguard/http/InterceptRedirectResponse.java
@@ -35,9 +35,9 @@ import org.owasp.csrfguard.ProtectionResult;
 import org.owasp.csrfguard.session.LogicalSession;
 import org.owasp.csrfguard.token.service.TokenService;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import javax.servlet.http.HttpServletResponseWrapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletResponseWrapper;
 import java.io.IOException;
 import java.util.Objects;
 

--- a/csrfguard/src/main/java/org/owasp/csrfguard/servlet/JavaScriptServlet.java
+++ b/csrfguard/src/main/java/org/owasp/csrfguard/servlet/JavaScriptServlet.java
@@ -42,10 +42,10 @@ import org.owasp.csrfguard.util.CsrfGuardUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.servlet.ServletConfig;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.ServletConfig;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -237,7 +237,7 @@ public final class JavaScriptServlet extends HttpServlet {
         try {
             return new URL(url.toString()).getHost();
         } catch (final MalformedURLException e) {
-            // Should not occur. javax.servlet.http.HttpServletRequest.getRequestURL should only return valid URLs.
+            // Should not occur. jakarta.servlet.http.HttpServletRequest.getRequestURL should only return valid URLs.
             return "INVALID_URL: " + url;
         }
     }

--- a/csrfguard/src/main/java/org/owasp/csrfguard/session/LogicalSession.java
+++ b/csrfguard/src/main/java/org/owasp/csrfguard/session/LogicalSession.java
@@ -28,7 +28,7 @@
  */
 package org.owasp.csrfguard.session;
 
-import javax.servlet.http.HttpSession;
+import jakarta.servlet.http.HttpSession;
 
 /**
  * Represents a logical session that enables decoupling from the container's session implementation in case the client application uses a stateless approach (e.g. token based authentication)
@@ -45,7 +45,7 @@ public interface LogicalSession {
      * Returns <code>true</code> if the client does not yet know about the
      * session or if the client chooses not to join the session.
      *
-     * @see javax.servlet.http.HttpSession#isNew()
+     * @see jakarta.servlet.http.HttpSession#isNew()
      *
      * @return <code>true</code> if the server has created a session, but the client has not yet joined
      */

--- a/csrfguard/src/main/java/org/owasp/csrfguard/token/service/TokenService.java
+++ b/csrfguard/src/main/java/org/owasp/csrfguard/token/service/TokenService.java
@@ -43,7 +43,7 @@ import org.owasp.csrfguard.token.transferobject.TokenTO;
 import org.owasp.csrfguard.util.CsrfGuardUtils;
 import org.owasp.csrfguard.util.MessageConstants;
 
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.Map;

--- a/csrfguard/src/main/java/org/owasp/csrfguard/token/storage/LogicalSessionExtractor.java
+++ b/csrfguard/src/main/java/org/owasp/csrfguard/token/storage/LogicalSessionExtractor.java
@@ -30,7 +30,7 @@ package org.owasp.csrfguard.token.storage;
 
 import org.owasp.csrfguard.session.LogicalSession;
 
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 
 public interface LogicalSessionExtractor {
 

--- a/csrfguard/src/main/java/org/owasp/csrfguard/util/CsrfGuardUtils.java
+++ b/csrfguard/src/main/java/org/owasp/csrfguard/util/CsrfGuardUtils.java
@@ -37,8 +37,8 @@ import org.owasp.csrfguard.token.transferobject.TokenTO;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;

--- a/csrfguard/src/test/java/org/owasp/csrfguard/config/dummy/DummyAction.java
+++ b/csrfguard/src/test/java/org/owasp/csrfguard/config/dummy/DummyAction.java
@@ -32,8 +32,8 @@ import org.owasp.csrfguard.CsrfGuard;
 import org.owasp.csrfguard.CsrfGuardException;
 import org.owasp.csrfguard.action.IAction;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.util.Collections;
 import java.util.Map;
 

--- a/csrfguard/src/test/java/org/owasp/csrfguard/config/dummy/DummyLogicalSessionExtractor.java
+++ b/csrfguard/src/test/java/org/owasp/csrfguard/config/dummy/DummyLogicalSessionExtractor.java
@@ -31,7 +31,7 @@ package org.owasp.csrfguard.config.dummy;
 import org.owasp.csrfguard.session.LogicalSession;
 import org.owasp.csrfguard.token.storage.LogicalSessionExtractor;
 
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 
 public class DummyLogicalSessionExtractor implements LogicalSessionExtractor {
 

--- a/pom.xml
+++ b/pom.xml
@@ -115,9 +115,12 @@
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
 
-        <servlet-api.version>2.5</servlet-api.version>
-        <jsp-api.version>2.2</jsp-api.version>
-        <jstl.version>1.2</jstl.version>
+        <!--<servlet-api.version>2.5</servlet-api.version>-->
+        <servlet-api.version>5.0.0</servlet-api.version>
+        <!-- <jsp-api.version>2.2</jsp-api.version>-->
+        <jsp-api.version>3.1.1</jsp-api.version>
+        <!--<jstl.version>1.2</jstl.version>-->
+        <jstl.version>3.0.0</jstl.version>
 
         <maven-surefire-plugin.version>3.0.0-M8</maven-surefire-plugin.version>
         <maven-jar-plugin.version>3.3.0</maven-jar-plugin.version>
@@ -147,24 +150,42 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
+                <groupId>jakarta.servlet</groupId>
+                <artifactId>jakarta.servlet-api</artifactId>
+                <version>${servlet-api.version}</version>
+                <scope>provided</scope>
+            </dependency>
+            <!--<dependency>
                 <groupId>javax.servlet</groupId>
                 <artifactId>servlet-api</artifactId>
                 <version>${servlet-api.version}</version>
                 <scope>provided</scope>
-            </dependency>
+            </dependency>-->
             <dependency>
+            	<groupId>jakarta.servlet.jsp</groupId>
+			        <artifactId>jakarta.servlet.jsp-api</artifactId>
+			        <version>${jsp-api.version}</version>
+              <scope>provided</scope>
+            </dependency>
+          <!--<dependency>
                 <groupId>javax.servlet.jsp</groupId>
                 <artifactId>jsp-api</artifactId>
                 <version>${jsp-api.version}</version>
                 <scope>provided</scope>
-            </dependency>
+            </dependency>-->
+          
             <dependency>
+            	<groupId>jakarta.servlet.jsp.jstl</groupId>
+		    	    <artifactId>jakarta.servlet.jsp.jstl-api</artifactId>
+    			    <version>${jstl.version}</version>
+              <scope>provided</scope>
+            </dependency>
+            <!--<dependency>
                 <groupId>javax.servlet.jsp.jstl</groupId>
                 <artifactId>jstl-api</artifactId>
                 <version>${jstl.version}</version>
                 <scope>provided</scope>
-            </dependency>
-
+            </dependency>-->
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -163,9 +163,9 @@
             </dependency>-->
             <dependency>
             	<groupId>jakarta.servlet.jsp</groupId>
-			        <artifactId>jakarta.servlet.jsp-api</artifactId>
-			        <version>${jsp-api.version}</version>
-              <scope>provided</scope>
+                <artifactId>jakarta.servlet.jsp-api</artifactId>
+                <version>${jsp-api.version}</version>
+                <scope>provided</scope>
             </dependency>
           <!--<dependency>
                 <groupId>javax.servlet.jsp</groupId>
@@ -173,12 +173,11 @@
                 <version>${jsp-api.version}</version>
                 <scope>provided</scope>
             </dependency>-->
-          
             <dependency>
-            	<groupId>jakarta.servlet.jsp.jstl</groupId>
-		    	    <artifactId>jakarta.servlet.jsp.jstl-api</artifactId>
-    			    <version>${jstl.version}</version>
-              <scope>provided</scope>
+                <groupId>jakarta.servlet.jsp.jstl</groupId>
+                <artifactId>jakarta.servlet.jsp.jstl-api</artifactId>
+                <version>${jstl.version}</version>
+                <scope>provided</scope>
             </dependency>
             <!--<dependency>
                 <groupId>javax.servlet.jsp.jstl</groupId>


### PR DESCRIPTION
Hi,

I see there isn't a jakarta.servlet version of the library.
With this PR I changed the dependencies in jakarta.servlet.* and modified the java classes accordingly.
It could be used/merged (perhaps into an alternative temporary branch) to those in need of Jakarta libraries dependencies.

Bye,
Stefano.