### PR TITLE
request through a proxyPass problem

### DIFF
--- a/csrfguard/src/main/java/org/owasp/csrfguard/servlet/JavaScriptServlet.java
+++ b/csrfguard/src/main/java/org/owasp/csrfguard/servlet/JavaScriptServlet.java
@@ -256,7 +256,7 @@ public final class JavaScriptServlet extends HttpServlet {
 				} catch (final MalformedURLException e) {
 					xForHost = null;
 				}
-			} else { // apache ProxyPass torna host:port, senza http/https 
+			} else { 
 				xForHost =  xForHost.split(":")[0];
 			}
 		}

--- a/csrfguard/src/main/java/org/owasp/csrfguard/servlet/JavaScriptServlet.java
+++ b/csrfguard/src/main/java/org/owasp/csrfguard/servlet/JavaScriptServlet.java
@@ -107,9 +107,9 @@ public final class JavaScriptServlet extends HttpServlet {
         JS_REPLACEMENT_MAP.put(X_REQUESTED_WITH_IDENTIFIER, (csrfGuard, request) -> StringUtils.defaultString(csrfGuard.getJavascriptXrequestedWith()));
         JS_REPLACEMENT_MAP.put(DYNAMIC_NODE_CREATION_EVENT_NAME_IDENTIFIER, (csrfGuard, request) -> StringUtils.defaultString(csrfGuard.getJavascriptDynamicNodeCreationEventName()));
         JS_REPLACEMENT_MAP.put(DOMAIN_ORIGIN_IDENTIFIER, (csrfGuard, request) -> ObjectUtils.firstNonNull(
-				csrfGuard.getDomainOrigin(),
-				getHostOrNull_Of_XForwardedHost(request.getHeader("X-Forwarded-Host")),
-				StringUtils.defaultString(JavaScriptServlet.parseDomain(request.getRequestURL()))));
+                csrfGuard.getDomainOrigin(),
+                getFirstHost(request.getHeader("X-Forwarded-Host")),
+                StringUtils.defaultString(JavaScriptServlet.parseDomain(request.getRequestURL()))));
         JS_REPLACEMENT_MAP.put(INJECT_INTO_FORMS_IDENTIFIER, (csrfGuard, request) -> Boolean.toString(csrfGuard.isJavascriptInjectIntoForms()));
         JS_REPLACEMENT_MAP.put(INJECT_GET_FORMS_IDENTIFIER, (csrfGuard, request) -> Boolean.toString(csrfGuard.isJavascriptInjectGetForms()));
         JS_REPLACEMENT_MAP.put(INJECT_FORM_ATTRIBUTES_IDENTIFIER, (csrfGuard, request) -> Boolean.toString(csrfGuard.isJavascriptInjectFormAttributes()));
@@ -245,23 +245,27 @@ public final class JavaScriptServlet extends HttpServlet {
         }
     }
 
-    private static String getHostOrNull_Of_XForwardedHost(String xForHost) {
-		if (StringUtils.isBlank(xForHost)) { 
-			xForHost = null;
-		}else {
-			xForHost = xForHost.split(",")[0];  // if there are multiple proxyPass in cascade, XForwardedHost became for example : "fox1:443, spring2:444", where fox1:443 is the first proxyPass encountered
-			if(xForHost.toLowerCase().startsWith("http")) {
-				try {
-					xForHost = new URL(xForHost).getHost();
-				} catch (final MalformedURLException e) {
-					xForHost = null;
-				}
-			} else { 
-				xForHost =  xForHost.split(":")[0];
-			}
-		}
-		return xForHost;
-	}
+    /**
+     * @param commaSeparatedHosts (e.g. "fox1:443, spring2:444"). Nullable
+     * @return the first host in the list(e.g. "fox1" without port number). null if commaSeparatedHosts is invalid/null/blank
+     */
+    private static String getFirstHost(String commaSeparatedHosts) {
+        if (StringUtils.isBlank(commaSeparatedHosts)) { 
+            commaSeparatedHosts = null;
+        }else {
+            commaSeparatedHosts = commaSeparatedHosts.split(",")[0];  // if there are multiple proxyPass in cascade, XForwardedHost became for example : "fox1:443, spring2:444", where fox1:443 is the first proxyPass encountered
+            if(commaSeparatedHosts.toLowerCase().startsWith("http")) {
+                try {
+                    commaSeparatedHosts = new URL(commaSeparatedHosts).getHost();
+                } catch (final MalformedURLException e) {
+                    commaSeparatedHosts = null;
+                }
+            } else { 
+                commaSeparatedHosts = commaSeparatedHosts.split(":")[0];
+            }
+        }
+        return commaSeparatedHosts;
+    }
 
     private void writeJavaScript(final CsrfGuard csrfGuard, final HttpServletRequest request, final HttpServletResponse response) throws IOException {
         final String refererHeader = request.getHeader("referer");


### PR DESCRIPTION
If the traffic flows across a proxyPass, this condition of csrfguard.js is not more satisfied. 

>  _if(isValidDomain(document.domain, "%DOMAIN_ORIGIN%")) {_

The user will receive this error: 

> "a OWASP CSRFGuard JavaScript was included from within an unauthorized domain". 

The problem lies in request.getRequestURL() used by JavaScriptServlet to get the _domain origin_. When there is a proxyPass between browser and web-Server, "request.getRequestURL()" returns the computer address of the local web-server as seen by the proxyPass server and not the external proxypass url requested by the client browser. 

In this pull-request I modified the JavaScriptServlet so that the class prefers the "X-Forwarded-Host" header if it was populated by proxyPass. This header identifies the original host requested by the client in the Host HTTP request header.


https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Host
