### PR TITLE
Fix none match multi domain validation

### DIFF
--- a/csrfguard/src/main/resources/csrfguard.js
+++ b/csrfguard/src/main/resources/csrfguard.js
@@ -227,6 +227,8 @@ if (owaspCSRFGuardScriptHasLoaded !== true) {
                         return true;
                     }
                 }
+                // In case none of the domain matches, return false
+                return false;
             }
 
             /* check exact or subdomain match */


### PR DESCRIPTION
### Original issue:
**Given** an array of domain to be validated by `isValidDomain()`
**When** no domain is valid 
**Then** the following error is produced
```
VM823:16 Uncaught TypeError: target.charAt is not a function
```
 
### Suggested fix:
 `isValidDomain()` to return `false` when multiple domain are evaluated and none matches.

 