### PR TITLE
Improve JavaScriptServlet client side caching strategy

### DIFF
--- a/csrfguard/src/main/java/org/owasp/csrfguard/CsrfGuard.java
+++ b/csrfguard/src/main/java/org/owasp/csrfguard/CsrfGuard.java
@@ -215,6 +215,10 @@ public final class CsrfGuard {
         return config().getJavascriptCacheControl();
     }
 
+    public String getJavascriptTaggedCacheControl() {
+        return config().getJavascriptTaggedCacheControl();
+    }
+
     public Pattern getJavascriptRefererPattern() {
         return config().getJavascriptRefererPattern();
     }

--- a/csrfguard/src/main/java/org/owasp/csrfguard/config/ConfigurationProvider.java
+++ b/csrfguard/src/main/java/org/owasp/csrfguard/config/ConfigurationProvider.java
@@ -184,6 +184,11 @@ public interface ConfigurationProvider {
     String getJavascriptCacheControl();
 
     /**
+     * @return the configured JavaScript cache control when queried using a tag query param
+     */
+    String getJavascriptTaggedCacheControl();
+
+    /**
      * @return the configured JavaScript "Referer" pattern to be used
      */
     Pattern getJavascriptRefererPattern();

--- a/csrfguard/src/main/java/org/owasp/csrfguard/config/NullConfigurationProvider.java
+++ b/csrfguard/src/main/java/org/owasp/csrfguard/config/NullConfigurationProvider.java
@@ -173,6 +173,10 @@ public final class NullConfigurationProvider implements ConfigurationProvider {
         return null;
     }
 
+    @Override public String getJavascriptTaggedCacheControl() {
+        return null;
+    }
+
     @Override
     public Pattern getJavascriptRefererPattern() {
         return null;

--- a/csrfguard/src/main/java/org/owasp/csrfguard/config/PropertiesConfigurationProvider.java
+++ b/csrfguard/src/main/java/org/owasp/csrfguard/config/PropertiesConfigurationProvider.java
@@ -117,6 +117,8 @@ public class PropertiesConfigurationProvider implements ConfigurationProvider {
 
 	private String javascriptCacheControl;
 
+	private String javascriptTaggedCacheControl;
+
 	private Pattern javascriptRefererPattern;
 
 	private boolean javascriptInjectIntoForms;
@@ -302,6 +304,10 @@ public class PropertiesConfigurationProvider implements ConfigurationProvider {
 	@Override
 	public String getJavascriptCacheControl() {
 		return this.javascriptCacheControl;
+	}
+
+	@Override public String getJavascriptTaggedCacheControl() {
+		return this.javascriptTaggedCacheControl;
 	}
 
 	@Override
@@ -548,6 +554,7 @@ public class PropertiesConfigurationProvider implements ConfigurationProvider {
 
 			if (servletConfig != null) {
 				this.javascriptCacheControl = getProperty(JavaScriptConfigParameters.CACHE_CONTROL, servletConfig);
+				this.javascriptTaggedCacheControl = getProperty(JavaScriptConfigParameters.CACHE_CONTROL_TAGGED, servletConfig);
 				this.javascriptDomainStrict = getProperty(JavaScriptConfigParameters.DOMAIN_STRICT, servletConfig);
 				this.javascriptInjectIntoAttributes = getProperty(JavaScriptConfigParameters.INJECT_INTO_ATTRIBUTES, servletConfig);
 				this.javascriptInjectGetForms = getProperty(JavaScriptConfigParameters.INJECT_GET_FORMS, servletConfig);

--- a/csrfguard/src/main/java/org/owasp/csrfguard/config/properties/javascript/JavaScriptConfigParameters.java
+++ b/csrfguard/src/main/java/org/owasp/csrfguard/config/properties/javascript/JavaScriptConfigParameters.java
@@ -40,6 +40,7 @@ public final class JavaScriptConfigParameters {
     // TODO document the names of the configurations that can be used for overriding the values from the web.xml in the properties file
 
     public static final StringJsConfigParameter CACHE_CONTROL = new StringJsConfigParameter("cache-control", "org.owasp.csrfguard.JavascriptServlet.cacheControl", "private, max-age=28800");
+    public static final StringJsConfigParameter CACHE_CONTROL_TAGGED = new StringJsConfigParameter("cache-control", "org.owasp.csrfguard.JavascriptServlet.cacheControlTagged", "private, max-age=600");
     public static final StringJsConfigParameter REFERER_PATTERN  = new StringJsConfigParameter("referer-pattern", "org.owasp.csrfguard.JavascriptServlet.refererPattern", DEFAULT_REFERER_PATTERN);
     public static final StringJsConfigParameter UNPROTECTED_EXTENSIONS = new StringJsConfigParameter("unprotected-extensions", "org.owasp.csrfguard.JavascriptServlet.UnprotectedExtensions", StringUtils.EMPTY);
     public static final StringJsConfigParameter SOURCE_FILE_LOCATION = new StringJsConfigParameter("source-file", "org.owasp.csrfguard.JavascriptServlet.sourceFile", null);

--- a/csrfguard/src/main/java/org/owasp/csrfguard/servlet/JavaScriptServlet.java
+++ b/csrfguard/src/main/java/org/owasp/csrfguard/servlet/JavaScriptServlet.java
@@ -270,7 +270,7 @@ public final class JavaScriptServlet extends HttpServlet {
                 } catch (final MalformedURLException e) {
                     commaSeparatedHosts = null;
                 }
-            } else {
+            } else { 
                 commaSeparatedHosts = commaSeparatedHosts.split(":")[0];
             }
         }

--- a/csrfguard/src/main/java/org/owasp/csrfguard/servlet/JavaScriptServlet.java
+++ b/csrfguard/src/main/java/org/owasp/csrfguard/servlet/JavaScriptServlet.java
@@ -232,7 +232,7 @@ public final class JavaScriptServlet extends HttpServlet {
         if (request.getParameter("tag") != null && request.getParameter("tag").equals(etag)) {
             response.setHeader("Cache-Control", csrfGuard.getJavascriptTaggedCacheControl());
         } else if (csrfGuard.isRotateEnabled() || csrfGuard.isTokenPerPageEnabled()) {
-            response.setHeader("Cache-Control", "private, must-revalidate, max-age=28800");
+            response.setHeader("Cache-Control", "private, no-cache, no-store, max-age=0");
         } else {
             response.setHeader("Cache-Control", csrfGuard.getJavascriptCacheControl());
         }

--- a/csrfguard/src/main/java/org/owasp/csrfguard/servlet/JavaScriptServlet.java
+++ b/csrfguard/src/main/java/org/owasp/csrfguard/servlet/JavaScriptServlet.java
@@ -260,7 +260,7 @@ public final class JavaScriptServlet extends HttpServlet {
      * @return the first host in the list(e.g. "fox1" without port number). null if commaSeparatedHosts is invalid/null/blank
      */
     private static String getFirstHost(String commaSeparatedHosts) {
-        if (StringUtils.isBlank(commaSeparatedHosts)) {
+        if (StringUtils.isBlank(commaSeparatedHosts)) { 
             commaSeparatedHosts = null;
         }else {
             commaSeparatedHosts = commaSeparatedHosts.split(",")[0];  // if there are multiple proxyPass in cascade, XForwardedHost became for example : "fox1:443, spring2:444", where fox1:443 is the first proxyPass encountered

--- a/csrfguard/src/main/java/org/owasp/csrfguard/util/ConvertUtil.java
+++ b/csrfguard/src/main/java/org/owasp/csrfguard/util/ConvertUtil.java
@@ -1,0 +1,50 @@
+/*
+ * The OWASP CSRFGuard Project, BSD License
+ * Copyright (c) 2011, Eric Sheridan (eric@infraredsecurity.com)
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of OWASP nor the names of its contributors may be used
+ *     to endorse or promote products derived from this software without specific
+ *     prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.owasp.csrfguard.util;
+
+import java.nio.charset.StandardCharsets;
+
+/**
+ * @author Jerome Blanchard
+ */
+public class ConvertUtil {
+
+    private static final byte[] HEX_ARRAY = "0123456789ABCDEF".getBytes(StandardCharsets.US_ASCII);
+
+    public static String bytesToHex(byte[] bytes) {
+        byte[] hexChars = new byte[bytes.length * 2];
+        for (int j = 0; j < bytes.length; j++) {
+            int v = bytes[j] & 0xFF;
+            hexChars[j * 2] = HEX_ARRAY[v >>> 4];
+            hexChars[j * 2 + 1] = HEX_ARRAY[v & 0x0F];
+        }
+        return new String(hexChars, StandardCharsets.UTF_8);
+    }
+}

--- a/csrfguard/src/main/resources/csrfguard.properties
+++ b/csrfguard/src/main/resources/csrfguard.properties
@@ -334,20 +334,20 @@ org.owasp.csrfguard.Config.Print = true
 # augmented by the JavaScriptServlet class.
 # If it's left blank, and it's not configured in the web.xml either, it defaults to META-INF/csrfguard.min.js.
 # Use of this property and the existence of the specified template file is required.
-org.owasp.csrfguard.JavascriptServlet.sourceFile =
+org.owasp.csrfguard.JavascriptServlet.sourceFile = 
 
 # Boolean value that determines whether or not the dynamic JavaScript code should be strict
-# with regards to what links it should inject the CSRF prevention token. With a value of true,
-# the JavaScript code will only place the token in links that point to the same exact domain
-# from which the HTML originated. With a value of false, the JavaScript code will place the
-# token in links that not only point to the same exact domain from which the HTML originated,
+# with regards to what links it should inject the CSRF prevention token. With a value of true, 
+# the JavaScript code will only place the token in links that point to the same exact domain 
+# from which the HTML originated. With a value of false, the JavaScript code will place the 
+# token in links that not only point to the same exact domain from which the HTML originated, 
 # but sub-domains as well.
 org.owasp.csrfguard.JavascriptServlet.domainStrict = true
 
-# Allows the developer to specify the value of the Cache-Control header in the HTTP response
+# Allows the developer to specify the value of the Cache-Control header in the HTTP response 
 # when serving the dynamic JavaScript file. The default value is private, max-age=28800.
-# Caching of the dynamic JavaScript file is intended to minimize traffic and improve performance.
-# Note that the Cache-Control header is always set to "no-store" when either the "Rotate"
+# Caching of the dynamic JavaScript file is intended to minimize traffic and improve performance. 
+# Note that the Cache-Control header is always set to "no-store" when either the "Rotate" 
 # "TokenPerPage" options is set to true in Owasp.CsrfGuard.properties.
 org.owasp.csrfguard.JavascriptServlet.cacheControl = private, max-age=28800
 
@@ -371,14 +371,14 @@ org.owasp.csrfguard.JavascriptServlet.refererPattern = .*
 # this property is not used
 org.owasp.csrfguard.JavascriptServlet.refererMatchProtocol = true
 
-# Similar to javascript servlet referer pattern, but this will make sure the referer of the
+# Similar to javascript servlet referer pattern, but this will make sure the referer of the 
 # javascript servlet matches the domain of the request. If there is no referer (proxy strips it?)
 # then it will not fail. Generally this is a good idea to be true.
 org.owasp.csrfguard.JavascriptServlet.refererMatchDomain = true
 
-# Boolean value that determines whether or not the dynamic JavaScript code should
-# inject the CSRF prevention token as a hidden field into HTML forms. The default
-# value is true. Developers are strongly discouraged from disabling this property
+# Boolean value that determines whether or not the dynamic JavaScript code should 
+# inject the CSRF prevention token as a hidden field into HTML forms. The default 
+# value is true. Developers are strongly discouraged from disabling this property 
 # as most server-side state changing actions are triggered via a POST request.
 org.owasp.csrfguard.JavascriptServlet.injectIntoForms = true
 
@@ -392,14 +392,14 @@ org.owasp.csrfguard.JavascriptServlet.injectGetForms = true
 org.owasp.csrfguard.JavascriptServlet.injectFormAttributes = true
 
 # Boolean value that determines whether or not the dynamic JavaScript code should
-# inject the CSRF prevention token in the query string of src and href attributes.
-# Injecting the CSRF prevention token in a URL resource increases its general risk
-# of exposure to unauthorized parties. However, most JavaEE web applications respond
-# in the exact same manner to HTTP requests and their associated parameters regardless
-# of the HTTP method. The risk associated with not protecting GET requests in this
-# situation is perceived greater than the risk of exposing the token in protected GET
-# requests. As a result, the default value of this attribute is set to true. Developers
-# that are confident their server-side state changing controllers will only respond to
+# inject the CSRF prevention token in the query string of src and href attributes. 
+# Injecting the CSRF prevention token in a URL resource increases its general risk 
+# of exposure to unauthorized parties. However, most JavaEE web applications respond 
+# in the exact same manner to HTTP requests and their associated parameters regardless 
+# of the HTTP method. The risk associated with not protecting GET requests in this 
+# situation is perceived greater than the risk of exposing the token in protected GET 
+# requests. As a result, the default value of this attribute is set to true. Developers 
+# that are confident their server-side state changing controllers will only respond to 
 # POST requests (i.e. discarding GET requests) are strongly encouraged to disable this property.
 org.owasp.csrfguard.JavascriptServlet.injectIntoAttributes = true
 
@@ -427,7 +427,7 @@ org.owasp.csrfguard.JavascriptServlet.injectIntoDynamicNodes = false
 
 org.owasp.csrfguard.JavascriptServlet.xRequestedWith = OWASP CSRFGuard Project
 
-# A comma separated list of file extensions can be added here to prevent the token from
+# A comma separated list of file extensions can be added here to prevent the token from 
 # being appended to them after pageload (which often causes a second copy of those static
 # resources to be downloaded). ex: "js,css,gif,png,ico,jpg"
 # org.owasp.csrfguard.JavascriptServlet.UnprotectedExtensions = js,css,gif,png,ico,jpg

--- a/csrfguard/src/main/resources/csrfguard.properties
+++ b/csrfguard/src/main/resources/csrfguard.properties
@@ -46,7 +46,7 @@ org.owasp.csrfguard.configuration.provider.factory = org.owasp.csrfguard.config.
 org.owasp.csrfguard.Enabled = true
 
 # If csrf guard filter should check even if there is no session for the user
-# Note: this changed around 2014/04, the default behavior used to be to
+# Note: this changed around 2014/04, the default behavior used to be to 
 # not check if there is no session. If you want the legacy behavior (if your app
 # is not susceptible to CSRF if the user has no session), set this to false
 org.owasp.csrfguard.ValidateWhenNoSessionExists = true

--- a/csrfguard/src/main/resources/csrfguard.properties
+++ b/csrfguard/src/main/resources/csrfguard.properties
@@ -46,7 +46,7 @@ org.owasp.csrfguard.configuration.provider.factory = org.owasp.csrfguard.config.
 org.owasp.csrfguard.Enabled = true
 
 # If csrf guard filter should check even if there is no session for the user
-# Note: this changed around 2014/04, the default behavior used to be to 
+# Note: this changed around 2014/04, the default behavior used to be to
 # not check if there is no session. If you want the legacy behavior (if your app
 # is not susceptible to CSRF if the user has no session), set this to false
 org.owasp.csrfguard.ValidateWhenNoSessionExists = true
@@ -334,29 +334,34 @@ org.owasp.csrfguard.Config.Print = true
 # augmented by the JavaScriptServlet class.
 # If it's left blank, and it's not configured in the web.xml either, it defaults to META-INF/csrfguard.min.js.
 # Use of this property and the existence of the specified template file is required.
-org.owasp.csrfguard.JavascriptServlet.sourceFile = 
+org.owasp.csrfguard.JavascriptServlet.sourceFile =
 
 # Boolean value that determines whether or not the dynamic JavaScript code should be strict
-# with regards to what links it should inject the CSRF prevention token. With a value of true, 
-# the JavaScript code will only place the token in links that point to the same exact domain 
-# from which the HTML originated. With a value of false, the JavaScript code will place the 
-# token in links that not only point to the same exact domain from which the HTML originated, 
+# with regards to what links it should inject the CSRF prevention token. With a value of true,
+# the JavaScript code will only place the token in links that point to the same exact domain
+# from which the HTML originated. With a value of false, the JavaScript code will place the
+# token in links that not only point to the same exact domain from which the HTML originated,
 # but sub-domains as well.
 org.owasp.csrfguard.JavascriptServlet.domainStrict = true
 
-# Allows the developer to specify the value of the Cache-Control header in the HTTP response 
+# Allows the developer to specify the value of the Cache-Control header in the HTTP response
 # when serving the dynamic JavaScript file. The default value is private, max-age=28800.
-# Caching of the dynamic JavaScript file is intended to minimize traffic and improve performance. 
-# Note that the Cache-Control header is always set to "no-store" when either the "Rotate" 
+# Caching of the dynamic JavaScript file is intended to minimize traffic and improve performance.
+# Note that the Cache-Control header is always set to "no-store" when either the "Rotate"
 # "TokenPerPage" options is set to true in Owasp.CsrfGuard.properties.
 org.owasp.csrfguard.JavascriptServlet.cacheControl = private, max-age=28800
 
-# Allows the developer to specify a regular expression describing the required value of the 
-# Referer header. Any attempts to access the servlet with a Referer header that does not 
-# match the captured expression is discarded. Inclusion of referer header checking is to 
-# help minimize the risk of JavaScript Hijacking attacks that attempt to steal tokens from 
-# the dynamically generated JavaScript. While the primary defenses against JavaScript 
-# Hijacking attacks are implemented within the dynamic JavaScript itself, referer header 
+# Allows the developer to specify the value of the Cache-Control header in the HTTP response
+# when serving the dynamic JavaScript file included with a tag query param that equals the generated ETag.
+# In that specific case you can assume a client cache without revalidation and use a custom cache duration.
+org.owasp.csrfguard.JavascriptServlet.cacheControlTagged = private, max-age=600
+
+# Allows the developer to specify a regular expression describing the required value of the
+# Referer header. Any attempts to access the servlet with a Referer header that does not
+# match the captured expression is discarded. Inclusion of referer header checking is to
+# help minimize the risk of JavaScript Hijacking attacks that attempt to steal tokens from
+# the dynamically generated JavaScript. While the primary defenses against JavaScript
+# Hijacking attacks are implemented within the dynamic JavaScript itself, referer header
 # checking is implemented to achieve defense in depth.
 org.owasp.csrfguard.JavascriptServlet.refererPattern = .*
 
@@ -365,14 +370,14 @@ org.owasp.csrfguard.JavascriptServlet.refererPattern = .*
 # this property is not used
 org.owasp.csrfguard.JavascriptServlet.refererMatchProtocol = true
 
-# Similar to javascript servlet referer pattern, but this will make sure the referer of the 
+# Similar to javascript servlet referer pattern, but this will make sure the referer of the
 # javascript servlet matches the domain of the request. If there is no referer (proxy strips it?)
 # then it will not fail. Generally this is a good idea to be true.
 org.owasp.csrfguard.JavascriptServlet.refererMatchDomain = true
 
-# Boolean value that determines whether or not the dynamic JavaScript code should 
-# inject the CSRF prevention token as a hidden field into HTML forms. The default 
-# value is true. Developers are strongly discouraged from disabling this property 
+# Boolean value that determines whether or not the dynamic JavaScript code should
+# inject the CSRF prevention token as a hidden field into HTML forms. The default
+# value is true. Developers are strongly discouraged from disabling this property
 # as most server-side state changing actions are triggered via a POST request.
 org.owasp.csrfguard.JavascriptServlet.injectIntoForms = true
 
@@ -386,14 +391,14 @@ org.owasp.csrfguard.JavascriptServlet.injectGetForms = true
 org.owasp.csrfguard.JavascriptServlet.injectFormAttributes = true
 
 # Boolean value that determines whether or not the dynamic JavaScript code should
-# inject the CSRF prevention token in the query string of src and href attributes. 
-# Injecting the CSRF prevention token in a URL resource increases its general risk 
-# of exposure to unauthorized parties. However, most JavaEE web applications respond 
-# in the exact same manner to HTTP requests and their associated parameters regardless 
-# of the HTTP method. The risk associated with not protecting GET requests in this 
-# situation is perceived greater than the risk of exposing the token in protected GET 
-# requests. As a result, the default value of this attribute is set to true. Developers 
-# that are confident their server-side state changing controllers will only respond to 
+# inject the CSRF prevention token in the query string of src and href attributes.
+# Injecting the CSRF prevention token in a URL resource increases its general risk
+# of exposure to unauthorized parties. However, most JavaEE web applications respond
+# in the exact same manner to HTTP requests and their associated parameters regardless
+# of the HTTP method. The risk associated with not protecting GET requests in this
+# situation is perceived greater than the risk of exposing the token in protected GET
+# requests. As a result, the default value of this attribute is set to true. Developers
+# that are confident their server-side state changing controllers will only respond to
 # POST requests (i.e. discarding GET requests) are strongly encouraged to disable this property.
 org.owasp.csrfguard.JavascriptServlet.injectIntoAttributes = true
 
@@ -421,7 +426,7 @@ org.owasp.csrfguard.JavascriptServlet.injectIntoDynamicNodes = false
 
 org.owasp.csrfguard.JavascriptServlet.xRequestedWith = OWASP CSRFGuard Project
 
-# A comma separated list of file extensions can be added here to prevent the token from 
+# A comma separated list of file extensions can be added here to prevent the token from
 # being appended to them after pageload (which often causes a second copy of those static
 # resources to be downloaded). ex: "js,css,gif,png,ico,jpg"
 # org.owasp.csrfguard.JavascriptServlet.UnprotectedExtensions = js,css,gif,png,ico,jpg

--- a/csrfguard/src/main/resources/csrfguard.properties
+++ b/csrfguard/src/main/resources/csrfguard.properties
@@ -354,6 +354,7 @@ org.owasp.csrfguard.JavascriptServlet.cacheControl = private, max-age=28800
 # Allows the developer to specify the value of the Cache-Control header in the HTTP response
 # when serving the dynamic JavaScript file included with a tag query param that equals the generated ETag.
 # In that specific case you can assume a client cache without revalidation and use a custom cache duration.
+# Be aware to NOT USE that option together with the "Rotate" or "TokenPerPage" options.
 org.owasp.csrfguard.JavascriptServlet.cacheControlTagged = private, max-age=600
 
 # Allows the developer to specify a regular expression describing the required value of the

--- a/pom.xml
+++ b/pom.xml
@@ -123,7 +123,7 @@
         <maven-jar-plugin.version>3.4.2</maven-jar-plugin.version>
         <maven-source-plugin.version>3.3.1</maven-source-plugin.version>
         <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
-        <maven-javadoc-plugin.version>3.10.1</maven-javadoc-plugin.version>
+        <maven-javadoc-plugin.version>3.11.1</maven-javadoc-plugin.version>
         <maven-war-plugin.version>3.4.0</maven-war-plugin.version>
         <maven-scm-plugin.version>2.1.0</maven-scm-plugin.version>
         <maven-release-plugin.version>3.1.1</maven-release-plugin.version>


### PR DESCRIPTION
This PR aims to improve client caching strategy for javascript csrf client.

Context : 
In our usage, we inject the script on pages using a ServletFilter that build the <script> and add it in the outgoing html. At that time, we have session information about user which query the page and we can decide a particular client side caching strategy for the csrf javascript client code using a watermark (tag) in the URL. That tag is based on the MD5 of the JS generated for that particular client and can then be cached during the session. 
If anything changes in the JS (including CSRF master token) the link won't be the same and not retrieved from browser cache.

The JavaScript servlet has been modified to take into consideration that query param (tag) and include a specific client cache header for that purpose. 
When param is not used, the servlet now include a ETag with a must revalidate strategy that will compare existing client side ETag avoiding, in case of same hash, to send again the content but a 304 response status code.

Modifications are mainly : 
- Add Etag in JS Servlet to avoid network bandwidth usage when file is the same (using md5)
- Externalize JavaScript Etag to allow custom client side strategy using the Etag in a query param for that script.
- Add a specific configuration to override cache-control when using tag query param to retrieve the clientside JS script.