### PR TITLE
Handle protocol (http, https) in URL normalisation.

### DIFF
--- a/csrfguard/src/main/resources/csrfguard.js
+++ b/csrfguard/src/main/resources/csrfguard.js
@@ -683,6 +683,7 @@ if (owaspCSRFGuardScriptHasLoaded !== true) {
 
                     /**
                      * For the library to function correctly, all the URLs must start with a forward slash (/)
+                     * or a full URL (http://example.com, https://example.com, //example.com).
                      * Parameters must be removed from the URL
                      */
                     var normalizeUrl = function(url) {

--- a/csrfguard/src/main/resources/csrfguard.js
+++ b/csrfguard/src/main/resources/csrfguard.js
@@ -691,10 +691,8 @@ if (owaspCSRFGuardScriptHasLoaded !== true) {
                             return index > 0 ? currentUrl.substring(0, index) : currentUrl;
                         }
 
-                        /*
-                         * TODO should other checks be done here like in the isValidUrl?
-                         * Could the url parameter contain full URLs with protocol domain, port etc?
-                         */
+                        let splittedUrl = /^(?:https?:)?\/\/[^\/]*(\/[^#?]*)?.*/.exec(url);
+                        url = (splittedUrl) ? splittedUrl[1] || "/" : url;
                         let normalizedUrl = startsWith(url, '/') ? url : '/' + url;
 
                         normalizedUrl = removeParameters(normalizedUrl, '?');


### PR DESCRIPTION
This PR aims to takes into consideration that normalized URLs may not be relative but contain a FQDN and a protocol.
The updated regexp will handle those cases : 
normalizeUrl("https://www.example.com/path/to/page");  ->  "/path/to/page"
normalizeUrl("http://www.example.com/path/to/page");  ->  "/path/to/page"
normalizeUrl("//www.example.com/path/to/page");  ->  "/path/to/page"
normalizeUrl("/absolute/path");  ->  "/absolute/path"
normalizeUrl("absolute/path");  ->  "/absolute/path"
normalizeUrl("http://example.com");  ->  "/"
normalizeUrl("//example.com");  ->  "/"
normalizeUrl("/");   ->  "/"