### PR TITLE
avoid using 'unload' event but 'pagehide'

### DIFF
--- a/csrfguard/src/main/resources/csrfguard.js
+++ b/csrfguard/src/main/resources/csrfguard.js
@@ -581,7 +581,7 @@ if (owaspCSRFGuardScriptHasLoaded !== true) {
                     });
 
                     formMutationObserver.observe(document, {attributes: false, childList: true, subtree: true});
-                    addEvent(window, 'unload', formMutationObserver.disconnect);
+                    addEvent(window, 'pagehide', formMutationObserver.disconnect);
                 } else {
                     addEvent(window, 'DOMNodeInserted', function (event) {
                         const target = event.target || event.srcElement;
@@ -610,7 +610,7 @@ if (owaspCSRFGuardScriptHasLoaded !== true) {
 
             var pageTokenWrapper = {pageTokens: {}};
 
-            addEvent(window, 'unload', EventCache.flush);
+            addEvent(window, 'pagehide', EventCache.flush);
 
             addEvent(window, 'DOMContentLoaded', function () {
                 isLoadedWrapper.isDomContentLoaded = true;


### PR DESCRIPTION
As mentioned in https://developer.mozilla.org/en-US/docs/Web/API/Window/unload_event#usage_notes  usage of 'unload' event is not recommended anymore. It also creates warning in PageSpeed Insights.

This PR aims to switch the usage of 'unload' event to 'pagehide'.